### PR TITLE
Update ruff pre-commit hook to use recommended ruff-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.12
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/keewis/blackdoc


### PR DESCRIPTION
## Summary
- Replace the legacy `ruff` hook id with the recommended `ruff-check` in pre-commit configuration
- Eliminates the "legacy alias" warning message that appears when running pre-commit

## Test plan
- [x] Run `pre-commit run --all-files` - all checks pass without warnings
- [x] Verify output shows `ruff check` instead of `ruff (legacy alias)`

🤖 Generated with [Claude Code](https://claude.ai/code)