### PR TITLE
fix: initialize output in allnan/anynan to prevent incorrect results

### DIFF
--- a/numbagg/funcs.py
+++ b/numbagg/funcs.py
@@ -29,6 +29,7 @@ F = TypeVar("F", bound=FloatArray)
     ]
 )
 def allnan(a: NumericArray, out: NumericArray) -> None:
+    out[0] = True
     for ai in a:
         if not np.isnan(ai):
             out[0] = False
@@ -44,6 +45,7 @@ def allnan(a: NumericArray, out: NumericArray) -> None:
     ]
 )
 def anynan(a: NumericArray, out: NumericArray) -> None:
+    out[0] = False
     for ai in a:
         if np.isnan(ai):
             out[0] = True

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -13,6 +13,8 @@ from numpy.testing import (
 
 from numbagg import (
     AGGREGATION_FUNCS,
+    allnan,
+    anynan,
     bfill,
     ffill,
     nanargmax,
@@ -249,3 +251,75 @@ def test_wraps():
     assert move_exp_nanmean.__name__ == "move_exp_nanmean"
     assert move_exp_nanmean.__repr__() == "numbagg.move_exp_nanmean"
     assert "Exponentially" in move_exp_nanmean.__doc__  # type: ignore
+
+
+class TestAllnanAnynanEdgeCases:
+    """Tests for allnan/anynan edge cases that require output initialization."""
+
+    def test_allnan_all_nans(self):
+        """allnan returns True when all values are NaN."""
+        arr = np.array([np.nan, np.nan, np.nan])
+        assert allnan(arr)
+
+    def test_allnan_single_nan(self):
+        """allnan returns True for a single NaN value."""
+        arr = np.array([np.nan])
+        assert allnan(arr)
+
+    def test_allnan_no_nans(self):
+        """allnan returns False when no values are NaN."""
+        arr = np.array([1.0, 2.0, 3.0])
+        assert not allnan(arr)
+
+    def test_allnan_mixed(self):
+        """allnan returns False when some values are NaN."""
+        arr = np.array([np.nan, 1.0, np.nan])
+        assert not allnan(arr)
+
+    def test_anynan_no_nans(self):
+        """anynan returns False when no values are NaN."""
+        arr = np.array([1.0, 2.0, 3.0])
+        assert not anynan(arr)
+
+    def test_anynan_single_non_nan(self):
+        """anynan returns False for a single non-NaN value."""
+        arr = np.array([1.0])
+        assert not anynan(arr)
+
+    def test_anynan_all_nans(self):
+        """anynan returns True when all values are NaN."""
+        arr = np.array([np.nan, np.nan, np.nan])
+        assert anynan(arr)
+
+    def test_anynan_mixed(self):
+        """anynan returns True when some values are NaN."""
+        arr = np.array([1.0, np.nan, 3.0])
+        assert anynan(arr)
+
+    def test_allnan_2d_axis(self):
+        """allnan works correctly with axis parameter on 2D arrays."""
+        arr = np.array([[np.nan, np.nan], [1.0, np.nan], [np.nan, np.nan]])
+        result = allnan(arr, axis=1)
+        expected = np.array([True, False, True])
+        assert_array_equal(result, expected)
+
+    def test_anynan_2d_axis(self):
+        """anynan works correctly with axis parameter on 2D arrays."""
+        arr = np.array([[1.0, 2.0], [1.0, np.nan], [3.0, 4.0]])
+        result = anynan(arr, axis=1)
+        expected = np.array([False, True, False])
+        assert_array_equal(result, expected)
+
+    def test_allnan_empty_along_axis(self):
+        """allnan handles edge case with 2D where entire row is NaN."""
+        arr = np.array([[np.nan, np.nan, np.nan], [1.0, 2.0, 3.0]])
+        result = allnan(arr, axis=1)
+        expected = np.array([True, False])
+        assert_array_equal(result, expected)
+
+    def test_anynan_empty_along_axis(self):
+        """anynan handles edge case with 2D where entire row has no NaN."""
+        arr = np.array([[1.0, 2.0, 3.0], [np.nan, np.nan, np.nan]])
+        result = anynan(arr, axis=1)
+        expected = np.array([False, True])
+        assert_array_equal(result, expected)


### PR DESCRIPTION
## Summary
- Fix `allnan` and `anynan` functions that failed to initialize output arrays before loops
- Add `out[0] = True` for `allnan` and `out[0] = False` for `anynan` before their loops
- Add edge case tests covering all-NaN arrays, no-NaN arrays, and multi-dimensional cases

The bug caused incorrect results when the early-return path wasn't taken:
- `allnan` returned `False` for all-NaN arrays (expected: `True`)
- `anynan` returned unpredictable values for no-NaN arrays (expected: `False`)

## Test plan
- [x] All existing tests pass (1062 passed)
- [x] New edge case tests added and passing
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)