### PR TITLE
fix: raise TypeError for bool input when supports_bool=False

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -554,6 +554,11 @@ class groupndreduce(NumbaBase):
             labels = labels.astype(dtype)
 
         if values.dtype == np.bool_:
+            if not self.supports_bool:
+                raise TypeError(
+                    f"{self.func.__name__} does not support boolean input. "
+                    "Convert to a numeric type first."
+                )
             values = values.astype(np.int32)
 
         if num_labels is None:
@@ -561,14 +566,9 @@ class groupndreduce(NumbaBase):
 
         target = self.target
 
-        # Use a float type. But TODO: I'm not confident when exactly numba will coerce
-        # vs. raise an error. If this is important we should decide + add tests
-        # (currently tests skip these cases, and IIUC the behavior changed when we added
-        # our own pre-type caching).
-        if (not self.supports_ints and np.issubdtype(values.dtype, np.integer)) or (
-            not self.supports_bool and values.dtype == np.bool_
-        ):
-            values_dtype = values.dtype
+        # Use a float type when the function doesn't support the input type.
+        if not self.supports_ints and np.issubdtype(values.dtype, np.integer):
+            values_dtype = np.dtype(np.float64)
             result_dtype: np.dtype = np.dtype(np.float64)
         else:
             values_dtype = values.dtype

--- a/numbagg/test/test_grouped.py
+++ b/numbagg/test/test_grouped.py
@@ -415,3 +415,16 @@ def test_dimensionality():
 
     with pytest.raises(ValueError):
         func(values2, labels)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [f for f in GROUPED_FUNCS if not f.supports_bool],
+)
+def test_bool_input_with_supports_bool_false(func):
+    """Test that bool input to functions with supports_bool=False raises TypeError."""
+    values = np.array([True, False, True, True, False], dtype=np.bool_)
+    labels = np.array([0, 0, 1, 1, 1], dtype=np.int64)
+
+    with pytest.raises(TypeError, match="does not support boolean input"):
+        func(values, labels, num_labels=2)


### PR DESCRIPTION
## Summary

- Fix bug where boolean input to grouped functions with `supports_bool=False` (like `group_nanvar` and `group_nanstd`) would fail with confusing numba TypeError
- Now raises clear `TypeError: group_nanvar does not support boolean input. Convert to a numeric type first.`
- Add test to verify the behavior

## Root cause

Boolean arrays were converted to `int32` *before* the `supports_bool` check, so `values.dtype == np.bool_` always evaluated to `False`, causing the check to be skipped.

## Test plan

- [x] New test `test_bool_input_with_supports_bool_false` verifies TypeError is raised
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)