### PR TITLE
fix: raise AxisError for out-of-bounds axis indices in move_axes

### DIFF
--- a/numbagg/test/test_utils.py
+++ b/numbagg/test/test_utils.py
@@ -1,6 +1,24 @@
 import numpy as np
+import pytest
 
 from numbagg.utils import move_axes
+
+
+def test_move_axes_rejects_out_of_bounds():
+    """move_axes should raise AxisError for out-of-bounds axis indices."""
+    arr = np.ones((3, 4, 5))
+
+    # Positive out-of-bounds
+    with pytest.raises(np.exceptions.AxisError):
+        move_axes(arr, (3,))
+    with pytest.raises(np.exceptions.AxisError):
+        move_axes(arr, (5,))
+
+    # Negative out-of-bounds
+    with pytest.raises(np.exceptions.AxisError):
+        move_axes(arr, (-4,))
+    with pytest.raises(np.exceptions.AxisError):
+        move_axes(arr, (-10,))
 
 
 def test_move_axes():

--- a/numbagg/utils.py
+++ b/numbagg/utils.py
@@ -21,8 +21,7 @@ def move_axes(arr: NDArray[T], axes: tuple[int, ...]):
     """
     Move & reshape a tuple of axes to an array's final axis, handling zero-length axes.
     """
-    # Normalize axes values to positive
-    axes = tuple(a % arr.ndim for a in axes)
+    # np.moveaxis handles negative indices and raises AxisError for out-of-bounds
 
     # Move specified axes to the end
     moved_arr = np.moveaxis(arr, axes, range(arr.ndim - len(axes), arr.ndim))


### PR DESCRIPTION
## Summary
- Fixed bug where `move_axes` used modulo (`%`) to normalize axis indices, silently wrapping out-of-bounds values instead of raising an error
- For example, `axis=5` on a 3D array would become `axis=2`, producing incorrect results without any warning
- Now delegates validation to `np.moveaxis`, which correctly raises `AxisError` for out-of-bounds indices

## Test plan
- [x] Added tests for positive out-of-bounds axis indices (3, 5 for 3D array)
- [x] Added tests for negative out-of-bounds axis indices (-4, -10 for 3D array)
- [x] Verified existing tests pass (valid negative indices still work)
- [x] Verified fix propagates to user-facing functions (`nansum`, `nanmean`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)